### PR TITLE
Add support for `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,8 @@ readme = "README.md"
 name = "tle_parser"
 
 [dependencies]
-nom = "5.1.0"
+nom = { version = "5.1.0", default-features = false }
+
+[features]
+default = ["std"]
+std = ["nom/std"]

--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ You can run this example with the following command:
 ```
 cargo run --example parse_iss_tle
 ```
+
+To use this crate in a no_std environment, include it in your Cargo.toml file with the following configuration:
+
+```
+tle_parser = { version = "0.x.y", default-features = false }
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,18 @@
-extern crate nom;
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+#[cfg(not(feature = "std"))]
+extern crate core as std;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(not(feature = "std"))]
+use alloc::{format, string::String};
+
+#[cfg(feature = "std")]
+use std::error;
+use std::fmt;
 
 use nom::{
     bytes::complete::{tag, take, take_until},
@@ -6,8 +20,6 @@ use nom::{
     sequence::tuple,
     IResult,
 };
-use std::error;
-use std::fmt;
 
 #[derive(Debug)]
 pub struct TLEError;
@@ -19,7 +31,7 @@ impl fmt::Display for TLEError {
         write!(f, "Invalid TLE Format")
     }
 }
-
+#[cfg(feature = "std")]
 impl error::Error for TLEError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         // Generic error, underlying cause isn't tracked.
@@ -170,8 +182,9 @@ pub fn parse(raw_tle: &str) -> Result<TLE> {
             map_res(take(1usize), |i: &str| i.parse::<u32>()),
         )),
     ))(raw_tle)
-    .map_err(|e| {
-        println!("🤔  Error - {}", e);
+    .map_err(|_e| {
+        #[cfg(feature = "std")]
+        println!("🤔  Error - {}", _e);
         TLEError
     })?;
 


### PR DESCRIPTION
### Description
This pull request adds support for `no_std` environments to the crate. By using conditional compilation with `cfg_attr` and feature flags, along with managing dependencies through feature flags, the crate can now be used in environments without the standard library.

### Changes Made
- Added `#![cfg_attr(not(feature = "std"), no_std)]` to the top of the crate to conditionally compile for `no_std` environments.
- Updated dependencies and imports to use `alloc` and `core` instead of `std` in `no_std` mode.
- Adjusted `Cargo.toml` to manage dependencies with feature flags, ensuring that only necessary dependencies are included based on the selected mode (`std` or `no_std`).

### Testing
Tested the crate locally to verify that it functions correctly in both `std` and `no_std` environments. Ensured compatibility with existing features and functionality.

### Additional Information
This change enhances the crate's versatility, allowing it to be used in a broader range of environments. Users can now choose between `std` and `no_std` modes based on their specific requirements, making the crate more accessible and adaptable.
